### PR TITLE
Demo: use pytest-xdist with pytest-split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run pytest
-        run: pytest --cov --splits 5 --group ${{ matrix.group }}
+        run: pytest --cov --splits 5 --group ${{ matrix.group }} -n 2
       - name: Upload coverage
         uses: actions/upload-artifact@v1
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pytest-split
+pytest-xdist


### PR DESCRIPTION
`pytest-split` works nicely also when combined with `pytest-xdist`. Test group 1 contains 6 tests which each take around 10 seconds to execute. With `-n 2` those 6 tests execute in around 30 seconds: https://github.com/jerry-git/pytest-split-gh-actions-demo/runs/549132036