### PR TITLE
Upgrade download-artifact to download all artifacts in one step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
@@ -21,7 +21,7 @@ jobs:
       - name: Run pytest
         run: pytest --cov --splits 5 --group ${{ matrix.group }}
       - name: Upload coverage
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: coverage${{ matrix.group }}
           path: .coverage
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
@@ -47,4 +47,4 @@ jobs:
           coverage combine coverage*/.coverage*
           coverage report --fail-under=100
           coverage xml
-      - uses: codecov/codecov-action@v1.0.6
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: [push]
+on: push
 
 jobs:
   test:
@@ -39,27 +39,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      # v2 will support downloading multiple with single step: https://github.com/actions/download-artifact/issues/23#issue-580701561
-      - name: Download coverage1
-        uses: actions/download-artifact@v1
-        with:
-          name: coverage1
-      - name: Download coverage2
-        uses: actions/download-artifact@v1
-        with:
-          name: coverage2
-      - name: Download coverage3
-        uses: actions/download-artifact@v1
-        with:
-          name: coverage3
-      - name: Download coverage4
-        uses: actions/download-artifact@v1
-        with:
-          name: coverage4
-      - name: Download coverage5
-        uses: actions/download-artifact@v1
-        with:
-          name: coverage5
+      - name: Download all artifacts
+        # Downloads coverage1, coverage2, etc.
+        uses: actions/download-artifact@v2
       - name: Run coverage
         run: |
           coverage combine coverage*/.coverage*


### PR DESCRIPTION
Hi!

This just updates the download-artifacts action now that v2 has been released 👏 

![image](https://user-images.githubusercontent.com/25310870/119539079-162c3880-bd8c-11eb-9c10-cabc93cf4e3c.png)

Seems to work as before 🙂 